### PR TITLE
chore: test canceling payment

### DIFF
--- a/src/Client/SogeCommerceGateway.php
+++ b/src/Client/SogeCommerceGateway.php
@@ -91,6 +91,15 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
         return $formToken;
     }
 
+    /**
+     * Cancels a payment via the SogeCommerce API.
+     *
+     * Official documentation:
+     * https://sogecommerce.societegenerale.eu/doc/en-EN/rest/V4.0/api/playground/Transaction/Cancel
+     *
+     * This method sends a POST request to the Transaction/Cancel endpoint to cancel an existing transaction,
+     * identified by its UUID. It throws an exception if the cancellation fails or if the API is not activated.
+     */
     public function cancelPayment(PaymentInterface $payment): void
     {
         $method = $payment->getMethod();
@@ -126,7 +135,7 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
                     'Content-Type' => 'application/json',
                 ],
                 'json' => [
-                    'paymentOrderId' => $transactions[0]['uuid'],
+                    'uuid' => $transactions[0]['uuid'],
                 ],
             ],
         );

--- a/tests/Application/templates/bundles/SyliusShopBundle/_scripts.html.twig
+++ b/tests/Application/templates/bundles/SyliusShopBundle/_scripts.html.twig
@@ -5,7 +5,6 @@
 
 <script type="text/javascript"
         src="https://static-sogecommerce.societegenerale.eu/static/js/krypton-client/V4.0/stable/kr-payment-form.min.js"
-        integrity="sha384-FIqRg5Z3CArcz1UvV7osFqEHYW01awqNCTwwTYoL6lhBgo7+3t9yswE3vO93wOGv"
         crossorigin="anonymous"
         kr-public-key="{{ akawaka_soge_commerce_public_key() }}"
         kr-post-url-success="{{ path('akawaka_soge_commerce_smart_form_after_submit') }}"


### PR DESCRIPTION
# Context

This PR is a draft and should be closed. Its purpose is to help test canceling a payment.

The payment has been hardcoded to be marked as failed. A call to `dd` is also present to display the API response and make it easy to retry by refreshing the page.

The currency has been hardcoded to `EUR` to ensure the bank can handle the payment.

# Setup

To test the payment, you should start the test application from the plugin. See [this link](https://github.com/Sylius/PluginSkeleton/tree/1.14?tab=readme-ov-file#docker) for instructions.

Please note that some files might not have the correct permissions. This can be easily fixed by using `chmod` on the host machine. Once the container has started, you should create the database and fixtures if they are not set up automatically:

```
docker compose exec app sh

tests/Application/bin/console doctrine:database:create
tests/Application/bin/console doctrine:schema:update --force
tests/Application/bin/console sylius:fixtures:load
```

You should now be able to access the application at http://localhost:8080/en_US/.

Please note that for some reason:

* Redirecting from http://localhost:8080/ to http://localhost:8080/{_locale} does not work for me.
* Adding items to the cart without being logged in does not work for me.

You can use the following accounts to test the shop and admin:

Shop: `shop@example.com` / `sylius`
Admin: `sylius` / `sylius`

Additionally, you should manually configure a Soge Commerce payment method to test the plugin. To do this, go to http://localhost:8080/admin/payment-methods/ and create the appropriate method. Enter the correct:

* User
* Password
* Public key
* HMAC SHA-256 key