### PR TITLE
fix: customer details in right index and change to order number for `orderId` generation

### DIFF
--- a/src/Client/OrderIdTransformer.php
+++ b/src/Client/OrderIdTransformer.php
@@ -17,9 +17,9 @@ use Akawaka\SyliusSogeCommercePlugin\Exception\InvalidOrderIdException;
 
 final class OrderIdTransformer implements OrderIdTransformerInterface
 {
-    public function transform(string $orderId, string $paymentId): string
+    public function transform(string $orderNumber, string $paymentId): string
     {
-        return sprintf('order-%s-payment-%s', $orderId, $paymentId);
+        return sprintf('order-%s-payment-%s', $orderNumber, $paymentId);
     }
 
     public function retrieve(string $value): string

--- a/src/Client/OrderIdTransformerInterface.php
+++ b/src/Client/OrderIdTransformerInterface.php
@@ -15,7 +15,7 @@ namespace Akawaka\SyliusSogeCommercePlugin\Client;
 
 interface OrderIdTransformerInterface
 {
-    public function transform(string $orderId, string $paymentId): string;
+    public function transform(string $orderNumber, string $paymentId): string;
 
     public function retrieve(string $value): string;
 

--- a/src/Client/SogeCommerceGateway.php
+++ b/src/Client/SogeCommerceGateway.php
@@ -63,26 +63,26 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
                 'json' => [
                     'amount' => $order->getTotal(),
                     'currency' => $order->getCurrencyCode(),
-                    'orderId' => $this->orderIdTransformer->transform((string) $order->getId(), (string) $payment->getId()),
+                    'orderId' => $this->orderIdTransformer->transform((string) $order->getNumber(), (string) $payment->getId()),
                     'customer' => [
                         'reference' => $order->getCustomer()?->getId(),
                         'email' => $order->getCustomer()?->getEmail(),
-                    ],
-                    'billingDetails' => [
-                        'firstName' => $this->sanitizeString($order->getBillingAddress()?->getFirstName()),
-                        'lastName' => $this->sanitizeString($order->getBillingAddress()?->getLastName()),
-                        'phoneNumber' => $this->sanitizeString($order->getBillingAddress()?->getPhoneNumber()),
-                        'address' => $this->sanitizeString($order->getBillingAddress()?->getStreet()),
-                        'zipCode' => $this->sanitizeString($order->getBillingAddress()?->getPostcode()),
-                        'city' => $this->sanitizeString($order->getBillingAddress()?->getCity()),
-                    ],
-                    'shippingDetails' => [
-                        'firstName' => $this->sanitizeString($order->getShippingAddress()?->getFirstName()),
-                        'lastName' => $this->sanitizeString($order->getShippingAddress()?->getLastName()),
-                        'phoneNumber' => $this->sanitizeString($order->getShippingAddress()?->getPhoneNumber()),
-                        'address' => $this->sanitizeString($order->getShippingAddress()?->getStreet()),
-                        'zipCode' => $this->sanitizeString($order->getShippingAddress()?->getPostcode()),
-                        'city' => $this->sanitizeString($order->getShippingAddress()?->getCity()),
+                        'billingDetails' => [
+                            'firstName' => $this->sanitizeString($order->getBillingAddress()?->getFirstName()),
+                            'lastName' => $this->sanitizeString($order->getBillingAddress()?->getLastName()),
+                            'phoneNumber' => $this->sanitizeString($order->getBillingAddress()?->getPhoneNumber()),
+                            'address' => $this->sanitizeString($order->getBillingAddress()?->getStreet()),
+                            'zipCode' => $this->sanitizeString($order->getBillingAddress()?->getPostcode()),
+                            'city' => $this->sanitizeString($order->getBillingAddress()?->getCity()),
+                        ],
+                        'shippingDetails' => [
+                            'firstName' => $this->sanitizeString($order->getShippingAddress()?->getFirstName()),
+                            'lastName' => $this->sanitizeString($order->getShippingAddress()?->getLastName()),
+                            'phoneNumber' => $this->sanitizeString($order->getShippingAddress()?->getPhoneNumber()),
+                            'address' => $this->sanitizeString($order->getShippingAddress()?->getStreet()),
+                            'zipCode' => $this->sanitizeString($order->getShippingAddress()?->getPostcode()),
+                            'city' => $this->sanitizeString($order->getShippingAddress()?->getCity()),
+                        ],
                     ],
                     'metadata' => [
                         SogeCommerceGatewayInterface::METADATA_METHOD => $method->getCode(),

--- a/tests/Unit/Client/FakeOrder.php
+++ b/tests/Unit/Client/FakeOrder.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Tests\Akawaka\SyliusSogeCommercePlugin\Unit\Client;
 
+use Sylius\Component\Core\Model\Address;
 use Sylius\Component\Core\Model\Customer;
 use Sylius\Component\Core\Model\Order;
-use Sylius\Component\Core\Model\Address;
 
 final class FakeOrder extends Order
 {

--- a/tests/Unit/Client/OrderIdTransformerTest.php
+++ b/tests/Unit/Client/OrderIdTransformerTest.php
@@ -21,9 +21,9 @@ final class OrderIdTransformerTest extends TestCase
     /**
      * @dataProvider provideTransform
      */
-    public function testTransform(string $orderId, string $paymentId, string $expectedResult): void
+    public function testTransform(string $orderNumber, string $paymentId, string $expectedResult): void
     {
-        self::assertEquals($expectedResult, (new OrderIdTransformer())->transform($orderId, $paymentId));
+        self::assertEquals($expectedResult, (new OrderIdTransformer())->transform($orderNumber, $paymentId));
     }
 
     public function provideTransform(): iterable

--- a/tests/Unit/Client/SogeCommerceGatewayTest.php
+++ b/tests/Unit/Client/SogeCommerceGatewayTest.php
@@ -67,26 +67,26 @@ final class SogeCommerceGatewayTest extends TestCase
                      'json' => [
                          'amount' => 4357,
                          'currency' => 'EUR',
-                         'orderId' => 'order-132-payment-1',
+                         'orderId' => 'order-ABC123-payment-1',
                          'customer' => [
                              'reference' => null, // client id
                              'email' => 'user@mail.com',
-                         ],
-                         'billingDetails' => [
-                             'firstName' => 'John',
-                             'lastName' => 'Doe',
-                             'phoneNumber' => '+33123456789',
-                             'address' => '',
-                             'zipCode' => '',
-                             'city' => '',
-                         ],
-                         'shippingDetails' => [
-                             'firstName' => null,
-                             'lastName' => null,
-                             'phoneNumber' => null,
-                             'address' => null,
-                             'zipCode' => null,
-                             'city' => null,
+                             'billingDetails' => [
+                                 'firstName' => 'John',
+                                 'lastName' => 'Doe',
+                                 'phoneNumber' => '+33123456789',
+                                 'address' => '',
+                                 'zipCode' => '',
+                                 'city' => '',
+                             ],
+                             'shippingDetails' => [
+                                 'firstName' => null,
+                                 'lastName' => null,
+                                 'phoneNumber' => null,
+                                 'address' => null,
+                                 'zipCode' => null,
+                                 'city' => null,
+                             ],
                          ],
                          'metadata' => [
                              'method' => 'my_payment_method',


### PR DESCRIPTION
- `billingDetails` and `shippingDetails` are now in right `customer` key
- `orderId` now use order number in place of id, to facilitate searching the order in Sylius back office