### PR TITLE
feat: upgrade to Sylius 1.13 and 1.14 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "sylius/sylius": "^1.12",
+        "php": "^8.1",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "sylius/sylius": "^1.13",
         "symfony/webpack-encore-bundle": "^1.15"
     },
     "require-dev": {

--- a/config/packages/nyholm_psr7.yaml
+++ b/config/packages/nyholm_psr7.yaml
@@ -1,0 +1,11 @@
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory

--- a/config/packages/workflow.yaml
+++ b/config/packages/workflow.yaml
@@ -1,0 +1,2 @@
+framework:
+    workflows: null

--- a/config/services/client.xml
+++ b/config/services/client.xml
@@ -5,6 +5,8 @@
         <service id="Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceGateway">
             <argument type="service" id="sylius.http_client" />
             <argument type="service" id="Akawaka\SyliusSogeCommercePlugin\Client\OrderIdTransformer" />
+            <argument type="service" id="Psr\Http\Message\RequestFactoryInterface" />
+            <argument type="service" id="Psr\Http\Message\StreamFactoryInterface" />
         </service>
 
         <service id="Akawaka\SyliusSogeCommercePlugin\Client\OrderIdTransformer" />

--- a/config/services/handler.xml
+++ b/config/services/handler.xml
@@ -8,7 +8,7 @@
         </service>
 
         <service id="Akawaka\SyliusSogeCommercePlugin\Handler\ProgressOrderStatusHandler">
-            <argument type="service" id="sm.factory" />
+            <argument type="service" id="Sylius\Abstraction\StateMachine\StateMachineInterface" />
         </service>
 
         <service id="Akawaka\SyliusSogeCommercePlugin\Handler\UpdateOrderPaymentMethodHandler" />

--- a/src/Client/SogeCommerceGateway.php
+++ b/src/Client/SogeCommerceGateway.php
@@ -18,7 +18,10 @@ use Akawaka\SyliusSogeCommercePlugin\Exception\InvalidPaymentMethodException;
 use Akawaka\SyliusSogeCommercePlugin\Exception\SogeCommerceApiException;
 use Akawaka\SyliusSogeCommercePlugin\Exception\SogeCommerceApiNotActivatedException;
 use Akawaka\SyliusSogeCommercePlugin\Payum\PaymentGatewayFactory;
-use GuzzleHttp\ClientInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
@@ -29,6 +32,8 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
     public function __construct(
         private ClientInterface $client,
         private OrderIdTransformerInterface $orderIdTransformer,
+        private RequestFactoryInterface $requestFactory,
+        private StreamFactoryInterface $streamFactory,
     ) {
     }
 
@@ -52,44 +57,41 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
         $payment = $order->getPayments()->last();
         Assert::isInstanceOf($payment, PaymentInterface::class);
 
-        $response = $this->client->request(
+        $request = $this->createJsonRequest(
             'POST',
             'https://api-sogecommerce.societegenerale.eu/api-payment/V4/Charge/CreatePayment',
+            $authorization,
             [
-                'headers' => [
-                    'Authorization' => sprintf('Basic %s', $authorization),
-                    'Content-Type' => 'application/json',
+                'amount' => $order->getTotal(),
+                'currency' => $order->getCurrencyCode(),
+                'orderId' => $this->orderIdTransformer->transform((string) $order->getId(), (string) $payment->getId()),
+                'customer' => [
+                    'reference' => $order->getCustomer()?->getId(),
+                    'email' => $order->getCustomer()?->getEmail(),
+                    'billingDetails' => [
+                        'firstName' => $this->sanitizeString($order->getBillingAddress()?->getFirstName()),
+                        'lastName' => $this->sanitizeString($order->getBillingAddress()?->getLastName()),
+                        'phoneNumber' => $this->sanitizeString($order->getBillingAddress()?->getPhoneNumber()),
+                        'address' => $this->sanitizeString($order->getBillingAddress()?->getStreet()),
+                        'zipCode' => $this->sanitizeString($order->getBillingAddress()?->getPostcode()),
+                        'city' => $this->sanitizeString($order->getBillingAddress()?->getCity()),
+                    ],
+                    'shippingDetails' => [
+                        'firstName' => $this->sanitizeString($order->getShippingAddress()?->getFirstName()),
+                        'lastName' => $this->sanitizeString($order->getShippingAddress()?->getLastName()),
+                        'phoneNumber' => $this->sanitizeString($order->getShippingAddress()?->getPhoneNumber()),
+                        'address' => $this->sanitizeString($order->getShippingAddress()?->getStreet()),
+                        'zipCode' => $this->sanitizeString($order->getShippingAddress()?->getPostcode()),
+                        'city' => $this->sanitizeString($order->getShippingAddress()?->getCity()),
+                    ],
                 ],
-                'json' => [
-                    'amount' => $order->getTotal(),
-                    'currency' => $order->getCurrencyCode(),
-                    'orderId' => $this->orderIdTransformer->transform((string) $order->getId(), (string) $payment->getId()),
-                    'customer' => [
-                        'reference' => $order->getCustomer()?->getId(),
-                        'email' => $order->getCustomer()?->getEmail(),
-                        'billingDetails' => [
-                            'firstName' => $this->sanitizeString($order->getBillingAddress()?->getFirstName()),
-                            'lastName' => $this->sanitizeString($order->getBillingAddress()?->getLastName()),
-                            'phoneNumber' => $this->sanitizeString($order->getBillingAddress()?->getPhoneNumber()),
-                            'address' => $this->sanitizeString($order->getBillingAddress()?->getStreet()),
-                            'zipCode' => $this->sanitizeString($order->getBillingAddress()?->getPostcode()),
-                            'city' => $this->sanitizeString($order->getBillingAddress()?->getCity()),
-                        ],
-                        'shippingDetails' => [
-                            'firstName' => $this->sanitizeString($order->getShippingAddress()?->getFirstName()),
-                            'lastName' => $this->sanitizeString($order->getShippingAddress()?->getLastName()),
-                            'phoneNumber' => $this->sanitizeString($order->getShippingAddress()?->getPhoneNumber()),
-                            'address' => $this->sanitizeString($order->getShippingAddress()?->getStreet()),
-                            'zipCode' => $this->sanitizeString($order->getShippingAddress()?->getPostcode()),
-                            'city' => $this->sanitizeString($order->getShippingAddress()?->getCity()),
-                        ],
-                    ],
-                    'metadata' => [
-                        SogeCommerceGatewayInterface::METADATA_METHOD => $method->getCode(),
-                    ],
+                'metadata' => [
+                    SogeCommerceGatewayInterface::METADATA_METHOD => $method->getCode(),
                 ],
             ],
         );
+
+        $response = $this->client->sendRequest($request);
 
         $data = json_decode((string) $response->getBody(), true);
         Assert::isArray($data);
@@ -143,19 +145,16 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
         Assert::isArray($transactions);
         Assert::isArray($transactions[0]);
 
-        $response = $this->client->request(
+        $request = $this->createJsonRequest(
             'POST',
             'https://api-sogecommerce.societegenerale.eu/api-payment/V4/Transaction/Cancel',
+            $authorization,
             [
-                'headers' => [
-                    'Authorization' => sprintf('Basic %s', $authorization),
-                    'Content-Type' => 'application/json',
-                ],
-                'json' => [
-                    'uuid' => $transactions[0]['uuid'],
-                ],
+                'uuid' => $transactions[0]['uuid'],
             ],
         );
+
+        $response = $this->client->sendRequest($request);
 
         $data = json_decode((string) $response->getBody(), true);
         Assert::isArray($data);
@@ -176,6 +175,17 @@ final class SogeCommerceGateway implements SogeCommerceGatewayInterface
     public function isPaymentSuccess(array $requestData): bool
     {
         return ($requestData['orderStatus'] ?? null) === 'PAID';
+    }
+
+    private function createJsonRequest(string $method, string $uri, string $authorization, array $body): RequestInterface
+    {
+        $request = $this->requestFactory->createRequest($method, $uri)
+            ->withHeader('Authorization', sprintf('Basic %s', $authorization))
+            ->withHeader('Content-Type', 'application/json');
+
+        return $request->withBody(
+            $this->streamFactory->createStream(json_encode($body, \JSON_THROW_ON_ERROR)),
+        );
     }
 
     private function sanitizeString(?string $value): ?string

--- a/src/Handler/ProgressOrderStatusHandler.php
+++ b/src/Handler/ProgressOrderStatusHandler.php
@@ -14,29 +14,28 @@ declare(strict_types=1);
 namespace Akawaka\SyliusSogeCommercePlugin\Handler;
 
 use Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceGatewayInterface;
-use SM\Factory\FactoryInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Webmozart\Assert\Assert;
 
 final class ProgressOrderStatusHandler implements ProgressOrderStatusHandlerInterface
 {
+    private const GRAPH = 'sylius_order_checkout';
+
     public function __construct(
-        private FactoryInterface $stateMachineFactory,
+        private StateMachineInterface $stateMachine,
     ) {
     }
 
     public function __invoke(OrderInterface $order, array $requestData): void
     {
-        $stateMachine = $this->stateMachineFactory->get($order, 'sylius_order_checkout');
-
-        if (OrderCheckoutStates::STATE_COMPLETED !== $stateMachine->getState()) {
-            $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
+        if ($this->stateMachine->can($order, self::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)) {
+            $this->stateMachine->apply($order, self::GRAPH, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
         }
 
-        if (OrderCheckoutStates::STATE_COMPLETED !== $stateMachine->getState()) {
-            $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_COMPLETE);
+        if ($this->stateMachine->can($order, self::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE)) {
+            $this->stateMachine->apply($order, self::GRAPH, OrderCheckoutTransitions::TRANSITION_COMPLETE);
         }
 
         $payment = $order->getLastPayment();

--- a/symfony.lock
+++ b/symfony.lock
@@ -25,6 +25,15 @@
             "ref": "64d8583af5ea57b7afa4aba4b159907f3a148b05"
         }
     },
+    "doctrine/deprecations": {
+        "version": "1.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "fdd756167454623e21f1d769c5b814b243782a67"
+        }
+    },
     "doctrine/doctrine-bundle": {
         "version": "2.13",
         "recipe": {
@@ -127,6 +136,18 @@
             "version": "1.8",
             "ref": "d1227d002b70d1a1f941d91845fcd7ac7fbfc929"
         }
+    },
+    "nyholm/psr7": {
+        "version": "1.8",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "4a8c0345442dcca1d8a2c65633dcf0285dd5a5a2"
+        },
+        "files": [
+            "config/packages/nyholm_psr7.yaml"
+        ]
     },
     "payum/payum-bundle": {
         "version": "2.6",
@@ -438,6 +459,18 @@
             "config/packages/webpack_encore.yaml",
             "package.json",
             "webpack.config.js"
+        ]
+    },
+    "symfony/workflow": {
+        "version": "6.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.3",
+            "ref": "3b2f8ca32a07fcb00f899649053943fa3d8bbfb6"
+        },
+        "files": [
+            "config/packages/workflow.yaml"
         ]
     },
     "willdurand/hateoas-bundle": {

--- a/tests/Unit/Client/SogeCommerceGatewayTest.php
+++ b/tests/Unit/Client/SogeCommerceGatewayTest.php
@@ -16,9 +16,13 @@ namespace Tests\Akawaka\SyliusSogeCommercePlugin\Unit\Client;
 use Akawaka\SyliusSogeCommercePlugin\Client\OrderIdTransformer;
 use Akawaka\SyliusSogeCommercePlugin\Client\OrderIdTransformerInterface;
 use Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceGateway;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfig;
 use Sylius\Component\Core\Model\PaymentMethod;
 
@@ -26,9 +30,15 @@ final class SogeCommerceGatewayTest extends TestCase
 {
     public function testCreateFormToken(): void
     {
+        $client = self::createMock(ClientInterface::class);
+        $requestFactory = self::createMock(RequestFactoryInterface::class);
+        $streamFactory = self::createMock(StreamFactoryInterface::class);
+
         $gateway = new SogeCommerceGateway(
-            $client = self::createMock(ClientInterface::class),
+            $client,
             new OrderIdTransformer(),
+            $requestFactory,
+            $streamFactory,
         );
 
         $method = new PaymentMethod();
@@ -54,56 +64,89 @@ final class SogeCommerceGatewayTest extends TestCase
             phone: '+33123456789',
         );
 
+        $capturedHeaders = [];
+        $request = self::createMock(RequestInterface::class);
+        $request->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$capturedHeaders, $request) {
+                $capturedHeaders[$name] = $value;
+
+                return $request;
+            });
+        $request->method('withBody')->willReturnSelf();
+
+        $requestFactory->expects(self::once())
+            ->method('createRequest')
+            ->with('POST', 'https://api-sogecommerce.societegenerale.eu/api-payment/V4/Charge/CreatePayment')
+            ->willReturn($request);
+
+        $capturedJson = null;
+        $stream = self::createMock(StreamInterface::class);
+        $streamFactory->expects(self::once())
+            ->method('createStream')
+            ->willReturnCallback(function (string $json) use (&$capturedJson, $stream) {
+                $capturedJson = $json;
+
+                return $stream;
+            });
+
+        $responseBody = self::createMock(StreamInterface::class);
+        $responseBody->method('__toString')->willReturn((string) json_encode([
+            'status' => 'SUCCESS',
+            'answer' => [
+                'formToken' => 'form_token',
+            ],
+        ]));
+
+        $response = self::createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn($responseBody);
+
         $client->expects(self::once())
-             ->method('request')
-             ->with(
-                 'POST',
-                 'https://api-sogecommerce.societegenerale.eu/api-payment/V4/Charge/CreatePayment',
-                 [
-                     'headers' => [
-                         'Authorization' => 'Basic bXlfdXNlcjpteV9wYXNzd29yZA==',
-                         'Content-Type' => 'application/json',
-                     ],
-                     'json' => [
-                         'amount' => 4357,
-                         'currency' => 'EUR',
-                         'orderId' => 'order-132-payment-1',
-                         'customer' => [
-                             'reference' => null, // client id
-                             'email' => 'user@mail.com',
-                             'billingDetails' => [
-                                 'firstName' => 'John',
-                                 'lastName' => 'Doe',
-                                 'phoneNumber' => '+33123456789',
-                                 'address' => '',
-                                 'zipCode' => '',
-                                 'city' => '',
-                             ],
-                             'shippingDetails' => [
-                                 'firstName' => null,
-                                 'lastName' => null,
-                                 'phoneNumber' => null,
-                                 'address' => null,
-                                 'zipCode' => null,
-                                 'city' => null,
-                             ],
-                         ],
-                         'metadata' => [
-                             'method' => 'my_payment_method',
-                         ],
-                    ],
-                ],
-             )
-            ->willReturn(new Response(
-                body: (string) json_encode([
-                    'status' => 'SUCCESS',
-                    'answer' => [
-                        'formToken' => 'form_token',
-                    ],
-                ]),
-            ));
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($response);
 
         self::assertEquals('form_token', $gateway->createFormToken($method, $order));
+
+        self::assertSame(
+            [
+                'Authorization' => 'Basic bXlfdXNlcjpteV9wYXNzd29yZA==',
+                'Content-Type' => 'application/json',
+            ],
+            $capturedHeaders,
+        );
+
+        self::assertNotNull($capturedJson);
+        self::assertJsonStringEqualsJsonString(
+            (string) json_encode([
+                'amount' => 4357,
+                'currency' => 'EUR',
+                'orderId' => 'order-132-payment-1',
+                'customer' => [
+                    'reference' => null,
+                    'email' => 'user@mail.com',
+                    'billingDetails' => [
+                        'firstName' => 'John',
+                        'lastName' => 'Doe',
+                        'phoneNumber' => '+33123456789',
+                        'address' => null,
+                        'zipCode' => null,
+                        'city' => null,
+                    ],
+                    'shippingDetails' => [
+                        'firstName' => null,
+                        'lastName' => null,
+                        'phoneNumber' => null,
+                        'address' => null,
+                        'zipCode' => null,
+                        'city' => null,
+                    ],
+                ],
+                'metadata' => [
+                    'method' => 'my_payment_method',
+                ],
+            ]),
+            $capturedJson,
+        );
     }
 
     /**
@@ -114,6 +157,8 @@ final class SogeCommerceGatewayTest extends TestCase
         $gateway = new SogeCommerceGateway(
             self::createMock(ClientInterface::class),
             self::createMock(OrderIdTransformerInterface::class),
+            self::createMock(RequestFactoryInterface::class),
+            self::createMock(StreamFactoryInterface::class),
         );
 
         self::assertEquals($expectedResult, $gateway->isPaymentSuccess($requestData));

--- a/tests/Unit/Handler/ProgressOrderStatusHandlerTest.php
+++ b/tests/Unit/Handler/ProgressOrderStatusHandlerTest.php
@@ -15,8 +15,7 @@ namespace Tests\Akawaka\SyliusSogeCommercePlugin\Unit\Handler;
 
 use Akawaka\SyliusSogeCommercePlugin\Handler\ProgressOrderStatusHandler;
 use PHPUnit\Framework\TestCase;
-use SM\Factory\FactoryInterface;
-use SM\StateMachine\StateMachineInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Model\Order;
 use Sylius\Component\Core\Model\Payment;
 
@@ -27,28 +26,25 @@ final class ProgressOrderStatusHandlerTest extends TestCase
         $order = new Order();
         $order->addPayment($payment = new Payment());
 
-        $stateMachineFactory = self::createMock(FactoryInterface::class);
-        $stateMachineFactory->expects(self::once())
-            ->method('get')
-            ->with($order, 'sylius_order_checkout')
-            ->willReturn($stateMachine = self::createMock(StateMachineInterface::class))
-        ;
+        $stateMachine = self::createMock(StateMachineInterface::class);
 
         $stateMachine->expects(self::exactly(2))
-            ->method('getState')
-            ->willReturn('shipping_selected')
-            ->willReturnOnConsecutiveCalls('shipping_selected', 'payment_selected');
+            ->method('can')
+            ->willReturnCallback(fn (object $subject, string $graph, string $transition) => match ($transition) {
+                'select_payment' => true,
+                'complete' => true,
+                default => throw new \LogicException(),
+            });
 
         $stateMachine->expects(self::exactly(2))
             ->method('apply')
-            ->willReturnCallback(fn (string $transition) => match (true) {
-                'select_payment' == $transition => true,
-                'complete' == $transition => true,
+            ->willReturnCallback(fn (object $subject, string $graph, string $transition) => match (true) {
+                'select_payment' === $transition => null,
+                'complete' === $transition => null,
                 default => throw new \LogicException(),
-            })
-        ;
+            });
 
-        (new ProgressOrderStatusHandler($stateMachineFactory))->__invoke($order, ['foo' => 'some data']);
+        (new ProgressOrderStatusHandler($stateMachine))->__invoke($order, ['foo' => 'some data']);
 
         self::assertEquals(['sogeCommerceRequestData' => ['foo' => 'some data']], $payment->getDetails());
     }
@@ -58,27 +54,21 @@ final class ProgressOrderStatusHandlerTest extends TestCase
         $order = new Order();
         $order->addPayment($payment = new Payment());
 
-        $stateMachineFactory = self::createMock(FactoryInterface::class);
-        $stateMachineFactory->expects(self::once())
-            ->method('get')
-            ->with($order, 'sylius_order_checkout')
-            ->willReturn($stateMachine = self::createMock(StateMachineInterface::class))
-        ;
+        $stateMachine = self::createMock(StateMachineInterface::class);
 
         $stateMachine->expects(self::exactly(2))
-            ->method('getState')
-            ->willReturn('shipping_selected')
-            ->willReturnOnConsecutiveCalls('shipping_selected', 'completed');
+            ->method('can')
+            ->willReturnCallback(fn (object $subject, string $graph, string $transition) => match ($transition) {
+                'select_payment' => true,
+                'complete' => false,
+                default => throw new \LogicException(),
+            });
 
         $stateMachine->expects(self::exactly(1))
             ->method('apply')
-            ->willReturnCallback(fn (string $transition) => match (true) {
-                'select_payment' == $transition => true,
-                default => throw new \LogicException(),
-            })
-        ;
+            ->with($order, 'sylius_order_checkout', 'select_payment');
 
-        (new ProgressOrderStatusHandler($stateMachineFactory))->__invoke($order, ['foo' => 'some data']);
+        (new ProgressOrderStatusHandler($stateMachine))->__invoke($order, ['foo' => 'some data']);
 
         self::assertEquals(['sogeCommerceRequestData' => ['foo' => 'some data']], $payment->getDetails());
     }
@@ -88,23 +78,16 @@ final class ProgressOrderStatusHandlerTest extends TestCase
         $order = new Order();
         $order->addPayment($payment = new Payment());
 
-        $stateMachineFactory = self::createMock(FactoryInterface::class);
-        $stateMachineFactory->expects(self::once())
-            ->method('get')
-            ->with($order, 'sylius_order_checkout')
-            ->willReturn($stateMachine = self::createMock(StateMachineInterface::class))
-        ;
+        $stateMachine = self::createMock(StateMachineInterface::class);
 
         $stateMachine->expects(self::exactly(2))
-            ->method('getState')
-            ->willReturn('completed')
-        ;
+            ->method('can')
+            ->willReturn(false);
 
-        $stateMachine->expects(self::exactly(0))
-            ->method('apply')
-        ;
+        $stateMachine->expects(self::never())
+            ->method('apply');
 
-        (new ProgressOrderStatusHandler($stateMachineFactory))->__invoke($order, ['foo' => 'some data']);
+        (new ProgressOrderStatusHandler($stateMachine))->__invoke($order, ['foo' => 'some data']);
 
         self::assertEquals(['sogeCommerceRequestData' => ['foo' => 'some data']], $payment->getDetails());
     }


### PR DESCRIPTION
This pull request updates the plugin to use PSR-7/PSR-17 HTTP abstractions and modernizes the codebase for compatibility with newer versions of dependencies. The most significant changes include switching from Guzzle to PSR-7/PSR-17 interfaces, updating the Sylius and PHP requirements, refactoring the `SogeCommerceGateway` and related tests, and updating the order state machine handling to use the new Sylius abstraction layer.

**HTTP Client and PSR-7/PSR-17 Integration:**

* Replaced Guzzle with PSR-7/PSR-17 interfaces in `SogeCommerceGateway`, updated constructor dependencies, and refactored request creation to use `RequestFactoryInterface` and `StreamFactoryInterface`. Added a helper method `createJsonRequest()` for JSON requests. (`src/Client/SogeCommerceGateway.php`, `config/services/client.xml`, [[1]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7L21-R24) [[2]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7R35-R36) [[3]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7L55-L63) [[4]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7L91-R95) [[5]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7L146-R158) [[6]](diffhunk://#diff-0cab80fc750eca8694587f5f85666c0bfa139d9e091cbd9011695fcb7325d9b7R180-R190) [[7]](diffhunk://#diff-cdd9b913aa7389262070394a29b98f4fa4da6cc49066a339ec2f6648bdd2d192R8-R9)
* Registered `nyholm/psr7` PSR-17 factories for autowiring in Symfony services. (`config/packages/nyholm_psr7.yaml`, [config/packages/nyholm_psr7.yamlR1-R11](diffhunk://#diff-54f2061bc8bbc4ab0e2b156b416a3f68fe87db212138fcedcbffcc9902fbe8e7R1-R11))
* Updated Composer requirements: raised PHP to ^8.1, Sylius to ^1.13, and added `psr/http-client` and `psr/http-factory` as dependencies. (`composer.json`, [composer.jsonL14-R17](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L14-R17))

**Order State Machine Refactor:**

* Replaced usage of `sm.factory` and `SM\Factory\FactoryInterface` with `Sylius\Abstraction\StateMachine\StateMachineInterface` in `ProgressOrderStatusHandler` and its tests, and refactored logic to use the new abstraction's `can` and `apply` methods. (`src/Handler/ProgressOrderStatusHandler.php`, `config/services/handler.xml`, [[1]](diffhunk://#diff-986c3511ae75a8fb62c9569b89b84625fa5194a129eda549b87c2195d91162e2L17-R38) [[2]](diffhunk://#diff-92d3ccca1c18022f5fa6aba6f2a3e9aaae40a4608047367a178092770084328aL11-R11)
* Updated related unit tests to mock the new state machine interface and adapt assertions and expectations. (`tests/Unit/Handler/ProgressOrderStatusHandlerTest.php`, [[1]](diffhunk://#diff-a1379e03bd72a7ca5713b68f620d8d215409df20d06ff85ac3150698bf5b7797L18-R18) [[2]](diffhunk://#diff-a1379e03bd72a7ca5713b68f620d8d215409df20d06ff85ac3150698bf5b7797L30-R47) [[3]](diffhunk://#diff-a1379e03bd72a7ca5713b68f620d8d215409df20d06ff85ac3150698bf5b7797L61-R71) [[4]](diffhunk://#diff-a1379e03bd72a7ca5713b68f620d8d215409df20d06ff85ac3150698bf5b7797L91-R90)

**Testing and Maintenance:**

* Refactored `SogeCommerceGatewayTest` to use PSR-7/PSR-17 mocks, updated test logic to assert request headers and JSON payloads, and adapted constructor calls to new dependencies. (`tests/Unit/Client/SogeCommerceGatewayTest.php`, [[1]](diffhunk://#diff-1217a6261e0d9ece65f566457d540816705fa161f7e1fbf23deed068c067022bL19-R41) [[2]](diffhunk://#diff-1217a6261e0d9ece65f566457d540816705fa161f7e1fbf23deed068c067022bR67-R133) [[3]](diffhunk://#diff-1217a6261e0d9ece65f566457d540816705fa161f7e1fbf23deed068c067022bL94-R149) [[4]](diffhunk://#diff-1217a6261e0d9ece65f566457d540816705fa161f7e1fbf23deed068c067022bR160-R161)

**Other:**

* Disabled Symfony workflows by setting `framework.workflows` to null. (`config/packages/workflow.yaml`, [config/packages/workflow.yamlR1-R2](diffhunk://#diff-859e89680f3d90f45abaf7ab3da05e099d870974b893dceb3f575bd9ff1e6f24R1-R2))