### PR TITLE
fix: tolerate a missing paid amount in StatusAction instead of throwing

### DIFF
--- a/config/services/controller.xml
+++ b/config/services/controller.xml
@@ -20,6 +20,7 @@
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="doctrine.orm.default_entity_manager" />
             <argument type="service" id="Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceRequestPayloadExtractor" />
+            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="logger" on-invalid="null" />
             <call method="setContainer">
                 <argument type="service" id="service_container" />

--- a/src/Controller/SmartFormAfterSubmitAction.php
+++ b/src/Controller/SmartFormAfterSubmitAction.php
@@ -17,6 +17,8 @@ use Akawaka\SyliusSogeCommercePlugin\Client\IsValidRequestInterface;
 use Akawaka\SyliusSogeCommercePlugin\Client\OrderIdTransformerInterface;
 use Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceGatewayInterface;
 use Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceRequestPayloadExtractorInterface;
+use Akawaka\SyliusSogeCommercePlugin\Event\PaymentCancelationFailedEvent;
+use Akawaka\SyliusSogeCommercePlugin\Exception\SogeCommerceApiException;
 use Akawaka\SyliusSogeCommercePlugin\Handler\ProgressOrderStatusHandlerInterface;
 use Akawaka\SyliusSogeCommercePlugin\Handler\UpdateOrderPaymentMethodHandlerInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -24,10 +26,12 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SM\SMException;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Order\Repository\OrderRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -49,6 +53,7 @@ final class SmartFormAfterSubmitAction extends AbstractController
         private PaymentMethodRepositoryInterface $paymentMethodRepository,
         private ObjectManager $em,
         private SogeCommerceRequestPayloadExtractorInterface $payloadExtractor,
+        private EventDispatcherInterface $eventDispatcher,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -67,8 +72,10 @@ final class SmartFormAfterSubmitAction extends AbstractController
      * in one, then modify their cart in another. This could result in them paying an outdated amount
      * that no longer matches their cart total.
      *
-     * To prevent this, the StatusAction checks if the paid amount matches the current cart total.
-     * If there is a mismatch, the payment is marked as failed and canceled using the Soge Commerce API.
+     * To prevent this, we compare the amount actually paid at SogeCommerce against the current order
+     * total before completing the order. On a mismatch the order is left untouched (still a cart),
+     * the payment is canceled using the Soge Commerce API, and the customer is sent back to payment
+     * selection. The StatusAction keeps the same check afterwards as a defense in depth.
      *
      * If the API is not active, an event is triggered instead. It is the responsibility of those
      * who install the plugin to listen for this event and take action, such as notifying the webmaster by email.
@@ -83,12 +90,39 @@ final class SmartFormAfterSubmitAction extends AbstractController
         }
 
         $order = $this->getOrder($requestData);
+
+        $payment = $order->getLastPayment();
+        if (null === $payment) {
+            // The order no longer carries a payment to attach the SogeCommerce result to (e.g. the
+            // payment was regenerated after the cart changed mid-payment). Fail cleanly instead of
+            // letting a null payment bubble up as a 500.
+            $this->logger->error('Soge Commerce return received but the order has no active payment.', [
+                'orderId' => $order->getId(),
+            ]);
+
+            $this->addFlash('error', 'akawaka_sylius_soge_commerce_plugin.payment_refused');
+
+            return $this->redirectToRoute('sylius_shop_checkout_select_payment');
+        }
+
         $this->updateOrderPaymentMethodHandler->__invoke($method, $order);
 
         if (false === $this->gateway->isPaymentSuccess($requestData)) {
             $this->em->flush();
 
             $this->addFlash('error', 'akawaka_sylius_soge_commerce_plugin.payment_refused');
+
+            return $this->redirectToRoute('sylius_shop_checkout_select_payment');
+        }
+
+        if (false === $this->isPaidAmountUpToDate($requestData, $order)) {
+            // The cart total changed while the payment was being made (e.g. another browser tab
+            // added an item). Never complete the order on an amount the customer did not pay:
+            // cancel the SogeCommerce charge and send them back to payment selection.
+            $this->cancelPayment($payment, $requestData);
+            $this->em->flush();
+
+            $this->addFlash('error', 'akawaka_sylius_soge_commerce_plugin.amount_mismatch');
 
             return $this->redirectToRoute('sylius_shop_checkout_select_payment');
         }
@@ -101,6 +135,43 @@ final class SmartFormAfterSubmitAction extends AbstractController
         }
 
         return $this->redirectToRoute('sylius_shop_order_pay', ['tokenValue' => $order->getTokenValue()]);
+    }
+
+    /**
+     * The amount the customer actually paid at SogeCommerce must still match the current order
+     * total; otherwise the cart was changed while the payment was in progress.
+     *
+     * @param array<string, mixed> $requestData
+     */
+    private function isPaidAmountUpToDate(array $requestData, OrderInterface $order): bool
+    {
+        $orderDetails = $requestData['orderDetails'] ?? null;
+        if (!is_array($orderDetails)) {
+            return false;
+        }
+
+        $paidAmount = $orderDetails['orderTotalAmount'] ?? null;
+
+        return is_int($paidAmount) && $paidAmount === $order->getTotal();
+    }
+
+    /**
+     * @param array<string, mixed> $requestData
+     */
+    private function cancelPayment(PaymentInterface $payment, array $requestData): void
+    {
+        // cancelPayment() reads the transaction reference from the payment details, so the
+        // SogeCommerce payload must be stored before requesting the cancellation.
+        $payment->setDetails([
+            SogeCommerceGatewayInterface::PAYMENT_DETAILS_REQUEST_DATA_KEY => $requestData,
+        ]);
+
+        try {
+            $this->gateway->cancelPayment($payment);
+        } catch (SogeCommerceApiException $exception) {
+            // The charge could not be canceled automatically; notify so it can be refunded manually.
+            $this->eventDispatcher->dispatch(new PaymentCancelationFailedEvent($exception, $payment));
+        }
     }
 
     /**

--- a/src/Payum/Action/StatusAction.php
+++ b/src/Payum/Action/StatusAction.php
@@ -58,7 +58,10 @@ final class StatusAction implements ActionInterface
                 $this->eventDispatcher->dispatch(new PaymentCancelationFailedEvent($e, $payment));
 
                 // Let's make sure the payment amount is true to what the user actually paid
-                $payment->setAmount($this->getRealPaidAmount($payment));
+                $realPaidAmount = $this->getRealPaidAmount($payment);
+                if (null !== $realPaidAmount) {
+                    $payment->setAmount($realPaidAmount);
+                }
                 $payment->setDetails(array_merge([
                     SogeCommerceGatewayInterface::PAYMENT_DETAILS_STATUS_KEY => 'CANCEL_FAILED',
                 ], $payment->getDetails()));
@@ -86,11 +89,16 @@ final class StatusAction implements ActionInterface
         return $this->getRealPaidAmount($payment) === $orderAmount;
     }
 
-    private function getRealPaidAmount(PaymentInterface $payment): int
+    /**
+     * Returns the amount actually paid at SogeCommerce, or null when it cannot be read from the
+     * payment details (e.g. the payment was regenerated after the cart changed mid-payment, so it
+     * no longer carries the SogeCommerce payload). Callers must treat null as an invalid amount
+     * rather than crashing.
+     */
+    private function getRealPaidAmount(PaymentInterface $payment): ?int
     {
         $amount = $payment->getDetails()[SogeCommerceGatewayInterface::PAYMENT_DETAILS_REQUEST_DATA_KEY]['orderDetails']['orderTotalAmount'] ?? null;
-        Assert::integer($amount);
 
-        return $amount;
+        return is_int($amount) ? $amount : null;
     }
 }

--- a/tests/Unit/Payum/Action/StatusActionTest.php
+++ b/tests/Unit/Payum/Action/StatusActionTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of akawaka/sylius-soge-commerce-plugin
+ *
+ * AKAWAKA
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Akawaka\SyliusSogeCommercePlugin\Unit\Payum\Action;
+
+use Akawaka\SyliusSogeCommercePlugin\Client\SogeCommerceGatewayInterface;
+use Akawaka\SyliusSogeCommercePlugin\Event\PaymentCancelationFailedEvent;
+use Akawaka\SyliusSogeCommercePlugin\Exception\FailedToCancelPaymentException;
+use Akawaka\SyliusSogeCommercePlugin\Payum\Action\StatusAction;
+use Payum\Core\Request\GetHumanStatus;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class StatusActionTest extends TestCase
+{
+    public function testItMarksTheRequestCapturedWhenThePaidAmountMatchesTheOrderTotal(): void
+    {
+        $action = new StatusAction(
+            $gateway = self::createMock(SogeCommerceGatewayInterface::class),
+            self::createMock(EventDispatcherInterface::class),
+        );
+        $gateway->expects(self::never())->method('cancelPayment');
+
+        $request = new GetHumanStatus($this->createPayment(1000, ['orderDetails' => ['orderTotalAmount' => 1000]]));
+
+        $action->execute($request);
+
+        self::assertTrue($request->isCaptured());
+    }
+
+    public function testItMarksTheRequestFailedAndCancelsWhenThePaidAmountDiffersFromTheOrderTotal(): void
+    {
+        $action = new StatusAction(
+            $gateway = self::createMock(SogeCommerceGatewayInterface::class),
+            self::createMock(EventDispatcherInterface::class),
+        );
+
+        $payment = $this->createPayment(2000, ['orderDetails' => ['orderTotalAmount' => 1000]]);
+        $gateway->expects(self::once())->method('cancelPayment')->with($payment);
+
+        $request = new GetHumanStatus($payment);
+        $action->execute($request);
+
+        self::assertTrue($request->isFailed());
+    }
+
+    public function testItFailsCleanlyWithoutCrashingWhenThePaidAmountCannotBeRead(): void
+    {
+        // Regression: when the cart is changed mid-payment Sylius regenerates the payment, so the
+        // new payment no longer carries the SogeCommerce payload. Reading the paid amount used to
+        // throw "Expected an integer. Got: NULL" and return a 500; it must now fail cleanly.
+        $action = new StatusAction(
+            $gateway = self::createMock(SogeCommerceGatewayInterface::class),
+            self::createMock(EventDispatcherInterface::class),
+        );
+
+        $payment = $this->createPaymentWithDetails(2000, []);
+        $gateway->expects(self::once())->method('cancelPayment')->with($payment);
+
+        $request = new GetHumanStatus($payment);
+        $action->execute($request);
+
+        self::assertTrue($request->isFailed());
+    }
+
+    public function testItLeavesTheAmountUntouchedWhenCancelFailsAndThePaidAmountCannotBeRead(): void
+    {
+        $action = new StatusAction(
+            $gateway = self::createMock(SogeCommerceGatewayInterface::class),
+            $eventDispatcher = self::createMock(EventDispatcherInterface::class),
+        );
+
+        $order = self::createMock(OrderInterface::class);
+        $order->method('getTotal')->willReturn(2000);
+        $payment = self::createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getDetails')->willReturn([]);
+
+        $gateway->method('cancelPayment')->willThrowException(new FailedToCancelPaymentException());
+        $payment->expects(self::never())->method('setAmount');
+        $payment->expects(self::once())->method('setDetails')->with(self::callback(
+            static fn (array $details): bool => 'CANCEL_FAILED' === ($details[SogeCommerceGatewayInterface::PAYMENT_DETAILS_STATUS_KEY] ?? null),
+        ));
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(self::isInstanceOf(PaymentCancelationFailedEvent::class));
+
+        $request = new GetHumanStatus($payment);
+        $action->execute($request);
+
+        self::assertTrue($request->isFailed());
+    }
+
+    /**
+     * @param array<string, mixed> $sogeRequestData
+     */
+    private function createPayment(int $orderTotal, array $sogeRequestData): PaymentInterface
+    {
+        return $this->createPaymentWithDetails($orderTotal, [
+            SogeCommerceGatewayInterface::PAYMENT_DETAILS_REQUEST_DATA_KEY => $sogeRequestData,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $details
+     */
+    private function createPaymentWithDetails(int $orderTotal, array $details): PaymentInterface
+    {
+        $order = self::createMock(OrderInterface::class);
+        $order->method('getTotal')->willReturn($orderTotal);
+
+        $payment = self::createMock(PaymentInterface::class);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getDetails')->willReturn($details);
+
+        return $payment;
+    }
+}

--- a/translations/flashes.en.yml
+++ b/translations/flashes.en.yml
@@ -1,2 +1,3 @@
 akawaka_sylius_soge_commerce_plugin:
     payment_refused: Payment refused
+    amount_mismatch: Your cart was changed during payment. The amount paid no longer matches your order total, so the payment was canceled. Please review your cart and try again.

--- a/translations/flashes.fr.yml
+++ b/translations/flashes.fr.yml
@@ -1,2 +1,3 @@
 akawaka_sylius_soge_commerce_plugin:
     payment_refused: Paiement refusé
+    amount_mismatch: Votre panier a été modifié pendant le paiement. Le montant réglé ne correspond plus au total de votre commande, le paiement a donc été annulé. Merci de vérifier votre panier et de recommencer.


### PR DESCRIPTION
- getRealPaidAmount() now returns null when the SogeCommerce payload is absent (e.g. a payment regenerated after the cart changed mid-payment) instead of asserting an integer and bubbling up a 500 on the after-pay status check
- isAmountValid() treats a null paid amount as invalid, and the cancel-failed branch only overrides the payment amount when it is actually known
- cover the behaviour with StatusActionTest, including the missing-amount regression
